### PR TITLE
Fixed that the game rules list implementation. #216

### DIFF
--- a/app/components/GameRulesOverlay.tsx
+++ b/app/components/GameRulesOverlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { FittedTileText } from "@/components/FittedTileText";
 import { useApi } from "@/hooks/useApi";
 
@@ -21,7 +21,52 @@ export function GameRulesOverlay({ token, isOpen, onClose }: Props) {
   const [gameModes, setGameModes] = useState<GameModeDTO[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
 
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+
+    const cards = Array.from(element.querySelectorAll(".rules-card"));
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const index = cards.indexOf(entry.target as Element);
+            setActiveIndex(index);
+          }
+        });
+      },
+      {
+        root: element,
+        threshold: 0.6,
+      }
+    );
+
+    cards.forEach((card) => observer.observe(card));
+
+    return () => observer.disconnect();
+  }, [gameModes, isOpen]);
+
+
+  const scrollToIndex = (i: number) => {
+    const element = scrollRef.current;
+    if (!element) return;
+
+    const card = element.querySelectorAll(".rules-card")[i] as HTMLElement;
+    if (!card) return;
+
+    card.scrollIntoView({
+      behavior: "smooth",
+      inline: "start",
+      block: "nearest",
+    });
+  };
+
+  
   // Fetch only when opened and if we don't have data yet
   React.useEffect(() => {
     if (isOpen && gameModes.length === 0 && token) {
@@ -42,7 +87,7 @@ export function GameRulesOverlay({ token, isOpen, onClose }: Props) {
           <h2 className="overlay-title">Game Rules</h2>
           
           <div className="rules-section">
-            <div className="rules-scroll-container">
+            <div className="rules-scroll-container" ref={scrollRef}>
               {loading ? (
                 <p className="overlay-error-bubble">Loading rules...</p>
               ) : error ? (
@@ -64,6 +109,17 @@ export function GameRulesOverlay({ token, isOpen, onClose }: Props) {
                 </div>
               )}
             </div>
+            {gameModes.length > 1 && (
+              <div className="rules-dots">
+                {gameModes.map((_, i) => (
+                  <span
+                    key={i}
+                    className={`dot ${i === activeIndex ? "active" : ""}`}
+                    onClick={() => scrollToIndex(i)}
+                  />
+                ))}
+              </div>
+            )}
           </div>
 
           <div className="rules-section">

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -2453,22 +2453,28 @@ a[href^="sms"] {
   z-index: 9999;
 }
 
+
 .rules-scroll-container {
   width: 100%;
   overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
 }
 
 .rules-horizontal-list {
   display: flex;
   gap: 16px;
-  padding: 8px 4px;
+  padding: 8px 0px;
+  scroll-snap-type: x mandatory;
 }
 
 .rules-card {
-  min-width: 260px;
-  max-width: 270px;
+  min-width: 100%;
+  max-width: 100%;
   flex-shrink: 0;
-
+  scroll-snap-align: start;
   background: rgba(255, 255, 255, 0.08);
   border-radius: 16px;
   padding: 16px;
@@ -2476,6 +2482,26 @@ a[href^="sms"] {
 
 .rules-scroll-container::-webkit-scrollbar {
   height: 6px;
+}
+
+.rules-dots {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.3);
+  transition: all 0.2s ease;
+}
+
+.dot.active {
+  background: white;
+  transform: scale(1.2);
 }
 
 /*CHAT--------------------------------*/


### PR DESCRIPTION
The rules are now centered.
Also added futer proof implementation: When more than 1 set of rules is fetched, the rules snap into place when scrolling + added dots at the bottom to indicate it can be scrolled, it shows on which page of rules you are, and you can also move to that page by clicking a dot.